### PR TITLE
Fix: Error Log

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -20,17 +20,18 @@ var loadCmd = &cobra.Command{
 
 		file, err := parser.ParseFileCommand()
 		if err != nil {
-			fmt.Printf("Error parsing command: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error parsing command: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Expected syntax: :=file_name\n")
 			return
 		}
 
 		content, err := os.ReadFile(file)
 		if err != nil {
-			fmt.Printf("Error reading file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error reading file '%s': %v\n", file, err)
 			return
 		}
 
 		loadedContent = string(content)
-		fmt.Printf("File '%s' successfully loaded in the system\n", file)
+		fmt.Printf("Successfully loaded file '%s' into memory.\n", file)
 	},
 }

--- a/cmd/replace.go
+++ b/cmd/replace.go
@@ -21,13 +21,19 @@ var replaceCmd = &cobra.Command{
 		parser := dsl.NewParser(input)
 		find, replace, file, err := parser.ParseReplaceCommand()
 		if err != nil {
-			fmt.Printf("Error parsing command: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Expected syntax: find:replace=file\n")
 			return
 		}
 
 		content, err := os.ReadFile(file)
 		if err != nil {
-			fmt.Printf("Error reading file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error reading file '%s': %v\n", file, err)
+			return
+		}
+
+		if input != string(content) {
+			fmt.Fprintf(os.Stderr, "We can't find the word '%s' in the file '%s'\n", find, file)
 			return
 		}
 
@@ -45,7 +51,7 @@ var replaceCmd = &cobra.Command{
 
 		err = os.WriteFile(file, []byte(text), 0644)
 		if err != nil {
-			fmt.Printf("Error writing to a file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error writing to file '%s': %v\n", file, err)
 			return
 		}
 		fmt.Printf("Successfully replaced '%s' with '%s' in file '%s'\n", find, replace, file)

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -23,10 +23,10 @@ var saveCmd = &cobra.Command{
 		}
 
 		if err := os.WriteFile(file, []byte(loadedContent), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "✖ Failed to save content to file '%s': %v\n", file, err)
+			fmt.Fprintf(os.Stderr, "Failed to save content to file '%s': %v\n", file, err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("✔ Successfully saved content to file '%s'.\n", file)
+		fmt.Printf("Successfully saved content to file '%s'.\n", file)
 	},
 }

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -17,15 +17,16 @@ var saveCmd = &cobra.Command{
 		parser := dsl.NewParser(input)
 		file, err := parser.ParseFileCommand()
 		if err != nil {
-			fmt.Printf("Error parsing command: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error parsing command: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Expected syntax: :=file_name\n")
 			return
 		}
 
 		if err := os.WriteFile(file, []byte(loadedContent), 0644); err != nil {
-			fmt.Printf("Failed to save a file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "✖ Failed to save content to file '%s': %v\n", file, err)
 			os.Exit(1)
 		}
 
-		fmt.Println("File saved successfully.")
+		fmt.Printf("✔ Successfully saved content to file '%s'.\n", file)
 	},
 }

--- a/dsl/parser.go
+++ b/dsl/parser.go
@@ -26,11 +26,11 @@ func NewParser(input string) *Parser {
 
 func (p *Parser) expect(expectedType TokenType) (Token, error) {
 	if p.pos >= len(p.tokens) {
-		return Token{}, fmt.Errorf("unexpected end of input")
+		return Token{}, fmt.Errorf("unexpected end of input: was expecting '%s' at position %d", expectedType, p.pos)
 	}
 	token := p.tokens[p.pos]
 	if token.Type != expectedType {
-		return Token{}, fmt.Errorf("expected %s, got %s", expectedType, token.Type)
+		return Token{}, fmt.Errorf("syntax error at position %d, expected '%s' but found '%s' (value: '%s')", p.pos, expectedType, token.Type, token.Value)
 	}
 	p.pos++
 	return token, nil
@@ -39,29 +39,29 @@ func (p *Parser) expect(expectedType TokenType) (Token, error) {
 func (p *Parser) ParseReplaceCommand() (find, replace, file string, err error) {
 	findToken, err := p.expect(TOKEN_ARG)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("failed to parse 'find' argument: %v", err)
 	}
 	find = findToken.Value
 
 	_, err = p.expect(TOKEN_COLON)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("missing ':' after 'find' argument: %v", err)
 	}
 
 	replaceToken, err := p.expect(TOKEN_ARG)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("failed to parse 'replace' argument: %v", err)
 	}
 	replace = replaceToken.Value
 
 	_, err = p.expect(TOKEN_EQUAL)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("missing '=' after 'replace' argument: %v", err)
 	}
 
 	fileToken, err := p.expect(TOKEN_ARG)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("failed to parse 'file' argument: %v", err)
 	}
 	file = fileToken.Value
 
@@ -70,15 +70,19 @@ func (p *Parser) ParseReplaceCommand() (find, replace, file string, err error) {
 
 func (p *Parser) ParseFileCommand() (string, error) {
 	if len(p.tokens) < 2 {
-		return "", fmt.Errorf("invalid load command syntax")
+		return "", fmt.Errorf("syntax error: input is too short. Expected ':=file_name', but got incomplete input")
 	}
 
 	// Token 0: := operator
 	if p.tokens[0].Value != ":=" {
-		return "", fmt.Errorf("expected ':=' for file assignment")
+		return "", fmt.Errorf("syntax error: expected ':=' at the beginning of the command but found '%s'", p.tokens[0].Value)
 	}
 
 	// Token 1: File name
 	file := p.tokens[1].Value
+	if file == "" {
+		return "", fmt.Errorf("syntax error: file name cannot be empty after ':='. Please provide a valid file name")
+	}
+
 	return file, nil
 }


### PR DESCRIPTION
- Add a more concise and clearer error log.
- Quick bug fix in the replace method, allowing users to perform find and replace successfully, even when the word they're looking for does not exist.
